### PR TITLE
Add ready and tool-registered events

### DIFF
--- a/.changeset/late-wombats-like.md
+++ b/.changeset/late-wombats-like.md
@@ -1,0 +1,5 @@
+---
+"@ludovicm67/simple-whiteboard": patch
+---
+
+Add "tool-registered" event

--- a/.changeset/wide-adults-jump.md
+++ b/.changeset/wide-adults-jump.md
@@ -1,0 +1,5 @@
+---
+"@ludovicm67/simple-whiteboard": patch
+---
+
+Add "ready" event

--- a/index.html
+++ b/index.html
@@ -31,11 +31,22 @@
       const id = Math.random().toString(36).substr(2, 9);
       const app = document.getElementById("app");
       (async () => {
+        // Listen for ready event
+        app.addEventListener("ready", (e) => {
+          console.info("Whiteboard is ready!", e.detail);
+        });
+
         // Just make sure that the simple-whiteboard element is defined
         await new Promise((resolve) => {
           window.customElements.whenDefined("simple-whiteboard").then(() => {
             resolve();
           });
+        });
+
+        // Listen for tool-registered event
+        app.addEventListener("tool-registered", (e) => {
+          const toolName = e.detail?.name || "Unknown";
+          console.log("Tool registered event:", toolName, e.detail);
         });
 
         // Listen for items-updated event

--- a/src/simple-whiteboard.ts
+++ b/src/simple-whiteboard.ts
@@ -404,6 +404,14 @@ export class SimpleWhiteboard extends LitElement {
     this.registeredTools.set(toolName, tool);
     this.draw();
     this.requestUpdate();
+
+    // Just send an event saying that a tool was registered
+    const toolRegistered = new CustomEvent("tool-registered", {
+      detail: {
+        name: toolName,
+      },
+    });
+    this.dispatchEvent(toolRegistered);
   }
 
   requestUpdate(

--- a/src/simple-whiteboard.ts
+++ b/src/simple-whiteboard.ts
@@ -73,6 +73,14 @@ export class SimpleWhiteboard extends LitElement {
     }
     this.canvasContext = canvasContext;
     this.handleResize();
+
+    // Just send a ready event ; the whiteboard element is available
+    const readyEvent = new CustomEvent("ready", {
+      detail: {
+        status: "ready",
+      },
+    });
+    this.dispatchEvent(readyEvent);
   }
 
   handleResize() {


### PR DESCRIPTION
This adds the following events:
- ready: the whiteboard HTML element is responsive, you should be able to use the functions exposed by the whiteboard
- tool-registered: a tool was registered, so you know all the tools that are ready ; you can for example delay some specific actions until all the tools you expect are registered