### PR TITLE
Cancel hover effect if not selecting item

### DIFF
--- a/.changeset/wide-needles-appear.md
+++ b/.changeset/wide-needles-appear.md
@@ -1,0 +1,5 @@
+---
+"@ludovicm67/simple-whiteboard": patch
+---
+
+Cancel hover effect if the user is not selecting an item

--- a/src/tools/pointer/tool.ts
+++ b/src/tools/pointer/tool.ts
@@ -78,8 +78,8 @@ export class PointerTool extends WhiteboardTool<PointerItem> {
       e.offsetY
     );
 
-    // Cancel the hover effect if the user is dragging an item
-    if (this.action === PointerAction.DRAG) {
+    // Cancel the hover effect if the user is not selecting an item
+    if (this.action !== PointerAction.SELECT) {
       const hoveredItemId = whiteboard.getHoveredItemId();
       if (hoveredItemId) {
         whiteboard.setHoveredItemId(null);


### PR DESCRIPTION
This disables the hover effect if the user is dragging (was already the case) or resizing an item.