### PR TITLE
Configure max size for pictures

### DIFF
--- a/.changeset/six-insects-carry.md
+++ b/.changeset/six-insects-carry.md
@@ -1,0 +1,5 @@
+---
+"@ludovicm67/simple-whiteboard": patch
+---
+
+It is possible to configure the max size of a picture

--- a/index.html
+++ b/index.html
@@ -44,9 +44,18 @@
         });
 
         // Listen for tool-registered event
-        app.addEventListener("tool-registered", (e) => {
-          const toolName = e.detail?.name || "Unknown";
-          console.log("Tool registered event:", toolName, e.detail);
+        let toolCounter = 0;
+        await new Promise((resolve) => {
+          app.addEventListener("tool-registered", (e) => {
+            const toolName = e.detail?.name || "Unknown";
+            console.log("Tool registered event:", toolName, e.detail);
+            toolCounter++;
+            console.log("Tool counter:", toolCounter);
+            if (toolCounter === 10) {
+              resolve();
+              console.log("All tools registered");
+            }
+          });
         });
 
         // Listen for items-updated event

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -35,6 +35,8 @@ export class DefaultTools extends LitElement {
       <simple-whiteboard--tool-text slot="tools"></simple-whiteboard--tool-text>
       <simple-whiteboard--tool-picture
         slot="tools"
+        maxWidth="120"
+        maxHeight="120"
       ></simple-whiteboard--tool-picture>
       <simple-whiteboard--tool-eraser
         slot="tools"

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -35,8 +35,8 @@ export class DefaultTools extends LitElement {
       <simple-whiteboard--tool-text slot="tools"></simple-whiteboard--tool-text>
       <simple-whiteboard--tool-picture
         slot="tools"
-        maxWidth="120"
-        maxHeight="120"
+        maxWidth="1200"
+        maxHeight="1200"
       ></simple-whiteboard--tool-picture>
       <simple-whiteboard--tool-eraser
         slot="tools"

--- a/src/tools/picture/element.ts
+++ b/src/tools/picture/element.ts
@@ -18,4 +18,14 @@ export class PictureElement extends WhiteboardElement<PictureTool> {
   constructor() {
     super(toolBuilder);
   }
+
+  protected updated(changedProperties: Map<string | number | symbol, unknown>) {
+    const tool = this.getTool();
+    if (changedProperties.has("maxWidth")) {
+      tool.setMaxWidth(this.maxWidth);
+    }
+    if (changedProperties.has("maxHeight")) {
+      tool.setMaxHeight(this.maxHeight);
+    }
+  }
 }

--- a/src/tools/picture/element.ts
+++ b/src/tools/picture/element.ts
@@ -1,5 +1,5 @@
 import { WhiteboardElement } from "../../lib/element";
-import { customElement } from "lit/decorators.js";
+import { customElement, property } from "lit/decorators.js";
 import { PictureTool } from "./tool";
 import { SimpleWhiteboard } from "../../simple-whiteboard";
 import { itemBuilder } from "./item";
@@ -9,6 +9,12 @@ const toolBuilder = (simpleWhiteboardInstance: SimpleWhiteboard) =>
 
 @customElement("simple-whiteboard--tool-picture")
 export class PictureElement extends WhiteboardElement<PictureTool> {
+  @property({ type: Number })
+  public maxWidth = 1200;
+
+  @property({ type: Number })
+  public maxHeight = 1200;
+
   constructor() {
     super(toolBuilder);
   }

--- a/src/tools/picture/tool.ts
+++ b/src/tools/picture/tool.ts
@@ -3,7 +3,6 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { WhiteboardTool } from "../../lib/tool";
 import { getIconSvg } from "../../lib/icons";
 import { PictureItem } from "./item";
-import { SimpleWhiteboard } from "../../simple-whiteboard";
 
 export const PICTURE_TOOL_NAME = "picture";
 
@@ -52,19 +51,25 @@ const resizeImage = (
 };
 
 export class PictureTool extends WhiteboardTool<PictureItem> {
-  private maxWidth: number;
-  private maxHeight: number;
+  private maxWidth: number = 1200;
+  private maxHeight: number = 1200;
 
-  constructor(
-    simpleWhiteboardInstance: SimpleWhiteboard,
-    itemBuilder: (item: any, id?: string) => PictureItem,
-    options?: { maxWidth?: number; maxHeight?: number }
-  ) {
-    super(simpleWhiteboardInstance, itemBuilder);
+  /**
+   * Set the maximum height of the image to be uploaded.
+   *
+   * @param maxWidth Maximum width of the image to be uploaded.
+   */
+  public setMaxWidth(maxWidth: number) {
+    this.maxWidth = maxWidth;
+  }
 
-    // Some custom options for the tool
-    this.maxHeight = options?.maxHeight ?? 1200;
-    this.maxWidth = options?.maxWidth ?? 1200;
+  /**
+   * Set the maximum height of the image to be uploaded.
+   *
+   * @param maxHeight Maximum height of the image to be uploaded.
+   */
+  public setMaxHeight(maxHeight: number) {
+    this.maxHeight = maxHeight;
   }
 
   /**


### PR DESCRIPTION
It is possible to define a `maxWidth` and `maxHeight` for the picture element.
This will configure the max size of an uploaded image (it will resize it to keep the aspect ratio).
This could be very useful in case the bandwidth is very limited and/or there are many updates on the whiteboard.