### PR TITLE
Reduce bundle size

### DIFF
--- a/.changeset/shiny-chicken-guess.md
+++ b/.changeset/shiny-chicken-guess.md
@@ -1,0 +1,5 @@
+---
+"@ludovicm67/simple-whiteboard": patch
+---
+
+Reduce bundle size

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "i18next": "^25.0.2",
         "lit": "^3.2.1",
-        "lucide-static": "^0.511.0",
+        "lucide": "^0.511.0",
         "perfect-freehand": "^1.2.2",
         "roughjs": "^4.6.6",
         "uuid": "^11.1.0"
@@ -2869,10 +2869,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/lucide-static": {
+    "node_modules/lucide": {
       "version": "0.511.0",
-      "resolved": "https://registry.npmjs.org/lucide-static/-/lucide-static-0.511.0.tgz",
-      "integrity": "sha512-/MWOjEyGZO84B16BeqbeleinbmeYxOBsbYDt/Yk6xGwMYwDm6dx43jKHMxGDqW9U84qWL13dNvVW0SMADhUSyg==",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.511.0.tgz",
+      "integrity": "sha512-3ppKPYcCJFXBloeM1H8OyIGjzINNQgsYvAYBTYOSKO45DF/5vbTQrCvwnvMDAGgDnUlI1uFxe0gJj52jdb1JAg==",
       "license": "ISC"
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "i18next": "^25.0.2",
     "lit": "^3.2.1",
-    "lucide-static": "^0.511.0",
+    "lucide": "^0.511.0",
     "perfect-freehand": "^1.2.2",
     "roughjs": "^4.6.6",
     "uuid": "^11.1.0"

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,4 +1,34 @@
-import * as icons from "lucide-static";
+import {
+  Circle,
+  createElement,
+  Edit2,
+  Eraser,
+  IconNode,
+  Image,
+  Menu,
+  Minus,
+  MousePointer,
+  Move,
+  Square,
+  Trash2,
+  Type,
+} from "lucide";
+
+const icons = {
+  Menu,
+
+  // Tools
+  Move,
+  MousePointer,
+  Square,
+  Circle,
+  Minus,
+  Edit2,
+  Type,
+  Image,
+  Eraser,
+  Trash2,
+};
 
 export type IconName = keyof typeof icons;
 export type IconNameExtended = IconName | (string & {});
@@ -15,26 +45,16 @@ export type IconOptions = Partial<{
  * @param name Name of the Lucide icon.
  * @returns The Lucide icon.
  */
-export const getIcon = (name: IconNameExtended): string => {
+export const getIcon = (name: IconNameExtended): IconNode => {
   if (!(iconNames as string[]).includes(name)) {
     throw new Error(`Icon "${name}" not found.`);
   }
-  return `${icons[name as IconName]}`; // Type assertion
+  return icons[name as IconName];
 };
 
 export const defaultSvgIconOptions: IconOptions = {
   width: 16,
   height: 16,
-};
-
-const createElementFromString = (htmlString: string): Element => {
-  const template = document.createElement("template");
-  template.innerHTML = htmlString.trim();
-  const element = template.content.firstElementChild;
-  if (!element) {
-    throw new Error("Invalid HTML string.");
-  }
-  return element;
 };
 
 /**
@@ -49,10 +69,9 @@ export const getIconSvg = (
   options?: IconOptions
 ): string => {
   const icon = getIcon(name);
-  const svgElement = createElementFromString(icon);
-  const iconOptions = { ...defaultSvgIconOptions, ...(options || {}) };
-  Object.entries(iconOptions).forEach(([key, value]) => {
-    svgElement.setAttribute(key, value.toString());
+  const svgElement = createElement(icon, {
+    ...defaultSvgIconOptions,
+    ...(options || {}),
   });
   return svgElement.outerHTML;
 };


### PR DESCRIPTION
The bundle size was very big once unpacked, as reported by npmjs: 3.56Mb.

This was because of all icons being included, even if they were not used.